### PR TITLE
edit mode: immediate update after parameter alteration 

### DIFF
--- a/app.html
+++ b/app.html
@@ -539,6 +539,7 @@ function SaveStyle(blade) {
   ret = ret.join(" ");
   presets[current_preset_num]["STYLE"+blade] = ret;
   Send("set_style"+blade+ " " + ret);
+  SetPreset(current_preset_num) //to make sure it takes immediate effect
 }
 
 function SaveName() {
@@ -562,6 +563,7 @@ function SaveFont() {
   if (presets[current_preset_num].FONT != font_select.value) {
     presets[current_preset_num].FONT = font_select.value;
     Send("set_font " + font_select.value);
+    SetPreset(current_preset_num) //to make sure it takes immediate effect
   }
 }
 
@@ -578,6 +580,7 @@ function SaveTrack() {
   if (presets[current_preset_num].TRACK != track_select.value) {
     presets[current_preset_num].TRACK = track_select.value;
     Send("set_track " + track_select.value);
+    SetPreset(current_preset_num) //to make sure it takes immediate effect
   }
 }
 


### PR DESCRIPTION
When in edit mode track, font or style (colors) is changed, preset will be re-selected to see the immediate effect on an ignited blade.
Other wise you have to manually changes presets and go back to make the alteration noticeable