### PR TITLE
edit mode: bugfix track selection displayed current track too far to the left

### DIFF
--- a/app.html
+++ b/app.html
@@ -129,6 +129,7 @@
   color: #FFFFFF;
   border: 0px;
   text-align: center;
+  text-align-last:center;
 }
 
 .myinput {
@@ -142,7 +143,7 @@
 
 .mybutton {
   font-family: StarJedi;
-  font-size: 130%;
+  font-size: 110%;
   line-height: 0.8;
   background: #101040;
   color: #FFFFFF;


### PR DESCRIPTION
bugfix track selection displayed current track too far to the left of longer tacks names in the selection list

Fixed that currently displayed track is centered in selection box