### PR TITLE
 scroll menu on android not working correctly

### DIFF
--- a/app.html
+++ b/app.html
@@ -232,6 +232,7 @@ html,
 .scrollable {
   overflow: auto;
   align: center;
+  height: 90%;
 }
 
 input[type="color"].custom {
@@ -1269,7 +1270,8 @@ function Init() {
 </div>
 
 <div class=content>
-  <div class=scrollable>
+
+  <div id=PRESETS class=scrollable>
     <div class=header>
        <span class=title>Presets</span>
     </div>


### PR DESCRIPTION
 scroll menu on android was missing the last menu item (or did not scroll at all)
 added height property to the scrollable class and set it to 90%
 it snow working again (also on pc, IOS)

Added an ID to the PRESETS container
Added blank line for better distinction between the container

	modified:   app.html